### PR TITLE
chore: Add base url to cypress.config.js

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -5,5 +5,6 @@ module.exports = defineConfig({
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },
+    baseUrl: "http://automationpractice.com/index.php"
   },
 });


### PR DESCRIPTION
As part of [Cypress Best Practices](https://docs.cypress.io/guides/references/best-practices#Setting-a-global-baseUrl), a base url was set for our tests.
